### PR TITLE
Escape quote marks in tags properly

### DIFF
--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -48,7 +48,7 @@ module TagHelper
     tags.each do |tag_type, name, count, id|
       name ||= "UNKNOWN"
 
-      html << %{<li class="tag-link tag-type-#{tag_type}" data-name="#{name}" data-type="#{tag_type}">}
+      html << %{<li class="tag-link tag-type-#{html_escape(tag_type)}" data-name="#{html_escape(name)}" data-type="#{html_escape(tag_type)}">}
 
       if CONFIG["enable_artists"] && tag_type == "artist"
         html << %{<a href="/artist/show?name=#{u(name)}">?</a> }


### PR DESCRIPTION
Tags with double quote marks were not treated correctly. In both of the following images, the tag in question was this_"is"_a_test ..

Before this commit:
![before](https://cloud.githubusercontent.com/assets/2147649/3295751/ab353a04-f5c9-11e3-84cd-2f5412327afb.png)

After this commit:
![after](https://cloud.githubusercontent.com/assets/2147649/3295752/aeffb4e8-f5c9-11e3-8b6f-de3c25f61171.png)

The tag with double quote marks would still show in the list on the left and be searchable, it just wouldn't be easy to edit it.
