### PR TITLE
Fix migration issues in Rails 5.1

### DIFF
--- a/db/migrate/001_add_post_links.rb
+++ b/db/migrate/001_add_post_links.rb
@@ -1,4 +1,4 @@
-class AddPostLinks < ActiveRecord::Migration
+class AddPostLinks < ActiveRecord::Migration[5.1]
   def self.up
     execute("ALTER TABLE posts ADD COLUMN next_post_id INTEGER REFERENCES posts ON DELETE SET NULL")
     execute("ALTER TABLE posts ADD COLUMN prev_post_id INTEGER REFERENCES posts ON DELETE SET NULL")

--- a/db/migrate/002_create_artists.rb
+++ b/db/migrate/002_create_artists.rb
@@ -1,4 +1,4 @@
-class CreateArtists < ActiveRecord::Migration
+class CreateArtists < ActiveRecord::Migration[5.1]
   def self.up
     execute(<<-EOS)
      CREATE TABLE artists (

--- a/db/migrate/003_extend_post_tag_histories.rb
+++ b/db/migrate/003_extend_post_tag_histories.rb
@@ -1,4 +1,4 @@
-class ExtendPostTagHistories < ActiveRecord::Migration
+class ExtendPostTagHistories < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE post_tag_histories ADD COLUMN user_id INTEGER REFERENCES users ON DELETE SET NULL"
     execute "ALTER TABLE post_tag_histories ADD COLUMN ip_addr TEXT"

--- a/db/migrate/004_post_tag_history_constraints.rb
+++ b/db/migrate/004_post_tag_history_constraints.rb
@@ -1,4 +1,4 @@
-class PostTagHistoryConstraints < ActiveRecord::Migration
+class PostTagHistoryConstraints < ActiveRecord::Migration[5.1]
   def self.up
     execute("UPDATE post_tag_histories SET created_at = now() WHERE created_at IS NULL")
     execute("UPDATE post_tag_histories SET ip_addr = '' WHERE ip_addr IS NULL")

--- a/db/migrate/005_create_forum_post.rb
+++ b/db/migrate/005_create_forum_post.rb
@@ -1,4 +1,4 @@
-class CreateForumPost < ActiveRecord::Migration
+class CreateForumPost < ActiveRecord::Migration[5.1]
   def self.up
     execute(<<-EOS)
       CREATE TABLE forum_posts (

--- a/db/migrate/006_create_forum_posts.rb
+++ b/db/migrate/006_create_forum_posts.rb
@@ -1,4 +1,4 @@
-class CreateForumPosts < ActiveRecord::Migration
+class CreateForumPosts < ActiveRecord::Migration[5.1]
   def self.up
   end
 

--- a/db/migrate/007_add_spam_field_to_comments.rb
+++ b/db/migrate/007_add_spam_field_to_comments.rb
@@ -1,4 +1,4 @@
-class AddSpamFieldToComments < ActiveRecord::Migration
+class AddSpamFieldToComments < ActiveRecord::Migration[5.1]
   def self.up
     execute("ALTER TABLE comments DROP COLUMN signal_level")
     execute("ALTER TABLE comments ADD COLUMN is_spam BOOLEAN")

--- a/db/migrate/008_upgrade_forums.rb
+++ b/db/migrate/008_upgrade_forums.rb
@@ -1,4 +1,4 @@
-class UpgradeForums < ActiveRecord::Migration
+class UpgradeForums < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE forum_posts ADD COLUMN reply_count INTEGER NOT NULL DEFAULT 0"
     execute "ALTER TABLE forum_posts ADD COLUMN last_updated_by INTEGER REFERENCES users ON DELETE SET NULL"

--- a/db/migrate/009_add_last_seen_forum_post_date.rb
+++ b/db/migrate/009_add_last_seen_forum_post_date.rb
@@ -1,4 +1,4 @@
-class AddLastSeenForumPostDate < ActiveRecord::Migration
+class AddLastSeenForumPostDate < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE users DROP COLUMN last_seen_forum_post_id"
     execute "ALTER TABLE users ADD COLUMN last_seen_forum_post_date TIMESTAMP NOT NULL DEFAULT now()"

--- a/db/migrate/010_add_user_fields.rb
+++ b/db/migrate/010_add_user_fields.rb
@@ -1,4 +1,4 @@
-class AddUserFields < ActiveRecord::Migration
+class AddUserFields < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE users ADD COLUMN email TEXT NOT NULL DEFAULT ''"
     execute "ALTER TABLE users ADD COLUMN tag_blacklist TEXT NOT NULL DEFAULT ''"

--- a/db/migrate/011_add_invites.rb
+++ b/db/migrate/011_add_invites.rb
@@ -1,4 +1,4 @@
-class AddInvites < ActiveRecord::Migration
+class AddInvites < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE users ADD COLUMN invite_count INTEGER NOT NULL DEFAULT 0"
     execute <<-EOS

--- a/db/migrate/012_rename_invite_email_field.rb
+++ b/db/migrate/012_rename_invite_email_field.rb
@@ -1,4 +1,4 @@
-class RenameInviteEmailField < ActiveRecord::Migration
+class RenameInviteEmailField < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE invites RENAME COLUMN invite_email TO email"
   end

--- a/db/migrate/013_drop_is_ambiguous_field_from_tags.rb
+++ b/db/migrate/013_drop_is_ambiguous_field_from_tags.rb
@@ -1,4 +1,4 @@
-class DropIsAmbiguousFieldFromTags < ActiveRecord::Migration
+class DropIsAmbiguousFieldFromTags < ActiveRecord::Migration[5.1]
   def self.up
   end
 

--- a/db/migrate/014_add_pending_to_aliases_and_implications.rb
+++ b/db/migrate/014_add_pending_to_aliases_and_implications.rb
@@ -1,4 +1,4 @@
-class AddPendingToAliasesAndImplications < ActiveRecord::Migration
+class AddPendingToAliasesAndImplications < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE tag_aliases ADD COLUMN is_pending BOOLEAN NOT NULL DEFAULT FALSE"
     execute "ALTER TABLE tag_implications ADD COLUMN is_pending BOOLEAN NOT NULL DEFAULT FALSE"

--- a/db/migrate/015_rename_implication_fields.rb
+++ b/db/migrate/015_rename_implication_fields.rb
@@ -1,4 +1,4 @@
-class RenameImplicationFields < ActiveRecord::Migration
+class RenameImplicationFields < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE tag_implications RENAME COLUMN parent_id TO consequent_id"
     execute "ALTER TABLE tag_implications RENAME COLUMN child_id TO predicate_id"

--- a/db/migrate/016_add_forum_posts_user_views.rb
+++ b/db/migrate/016_add_forum_posts_user_views.rb
@@ -1,4 +1,4 @@
-class AddForumPostsUserViews < ActiveRecord::Migration
+class AddForumPostsUserViews < ActiveRecord::Migration[5.1]
   def self.up
     execute <<-EOS
       CREATE TABLE forum_posts_user_views (

--- a/db/migrate/017_drop_last_seen_forum_post_date_from_users.rb
+++ b/db/migrate/017_drop_last_seen_forum_post_date_from_users.rb
@@ -1,4 +1,4 @@
-class DropLastSeenForumPostDateFromUsers < ActiveRecord::Migration
+class DropLastSeenForumPostDateFromUsers < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE users DROP COLUMN last_seen_forum_post_date"
   end

--- a/db/migrate/018_add_constraints_to_forum_posts_user_views.rb
+++ b/db/migrate/018_add_constraints_to_forum_posts_user_views.rb
@@ -1,4 +1,4 @@
-class AddConstraintsToForumPostsUserViews < ActiveRecord::Migration
+class AddConstraintsToForumPostsUserViews < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE forum_posts_user_views ADD CONSTRAINT forum_posts_user_views__unique_forum_post_id_user_id UNIQUE (forum_post_id, user_id)"
     execute "CREATE INDEX forum_posts__parent_id_idx ON forum_posts (parent_id) WHERE parent_id IS NULL"

--- a/db/migrate/019_add_id_to_forum_posts_user_views.rb
+++ b/db/migrate/019_add_id_to_forum_posts_user_views.rb
@@ -1,4 +1,4 @@
-class AddIdToForumPostsUserViews < ActiveRecord::Migration
+class AddIdToForumPostsUserViews < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE forum_posts_user_views ADD COLUMN id SERIAL PRIMARY KEY"
   end

--- a/db/migrate/020_change_artists_a.rb
+++ b/db/migrate/020_change_artists_a.rb
@@ -1,4 +1,4 @@
-class ChangeArtistsA < ActiveRecord::Migration
+class ChangeArtistsA < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE artists ADD PRIMARY KEY (id)"
     execute "ALTER TABLE artists ADD COLUMN alias_id INTEGER REFERENCES artists ON DELETE SET NULL"

--- a/db/migrate/021_change_artists_b.rb
+++ b/db/migrate/021_change_artists_b.rb
@@ -1,4 +1,4 @@
-class ChangeArtistsB < ActiveRecord::Migration
+class ChangeArtistsB < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE artists DROP COLUMN japanese_name"
     execute "ALTER TABLE artists DROP COLUMN personal_name"

--- a/db/migrate/022_add_notes_to_artists.rb
+++ b/db/migrate/022_add_notes_to_artists.rb
@@ -1,4 +1,4 @@
-class AddNotesToArtists < ActiveRecord::Migration
+class AddNotesToArtists < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table artists add column notes text not null default ''"
   end

--- a/db/migrate/023_add_updated_at_to_artists.rb
+++ b/db/migrate/023_add_updated_at_to_artists.rb
@@ -1,4 +1,4 @@
-class AddUpdatedAtToArtists < ActiveRecord::Migration
+class AddUpdatedAtToArtists < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE artists ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT now()"
   end

--- a/db/migrate/024_drop_extra_indexes_on_artists.rb
+++ b/db/migrate/024_drop_extra_indexes_on_artists.rb
@@ -1,4 +1,4 @@
-class DropExtraIndexesOnArtists < ActiveRecord::Migration
+class DropExtraIndexesOnArtists < ActiveRecord::Migration[5.1]
   def self.up
     execute "DROP INDEX idx_artists__image_url"
     execute "DROP INDEX idx_favorites__post_user"

--- a/db/migrate/025_add_updater_id_to_artists.rb
+++ b/db/migrate/025_add_updater_id_to_artists.rb
@@ -1,4 +1,4 @@
-class AddUpdaterIdToArtists < ActiveRecord::Migration
+class AddUpdaterIdToArtists < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE artists ADD COLUMN updater_id INTEGER REFERENCES users ON DELETE SET NULL"
   end

--- a/db/migrate/026_add_ambiguous_field_to_tags.rb
+++ b/db/migrate/026_add_ambiguous_field_to_tags.rb
@@ -1,4 +1,4 @@
-class AddAmbiguousFieldToTags < ActiveRecord::Migration
+class AddAmbiguousFieldToTags < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table tags add column is_ambiguous boolean not null default false"
     execute "update tags set is_ambiguous = true where tag_type = 2"

--- a/db/migrate/027_add_response_count_to_forum.rb
+++ b/db/migrate/027_add_response_count_to_forum.rb
@@ -1,4 +1,4 @@
-class AddResponseCountToForum < ActiveRecord::Migration
+class AddResponseCountToForum < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE forum_posts ADD COLUMN response_count INTEGER NOT NULL DEFAULT 0"
   end

--- a/db/migrate/028_add_image_resize_user_setting.rb
+++ b/db/migrate/028_add_image_resize_user_setting.rb
@@ -1,4 +1,4 @@
-class AddImageResizeUserSetting < ActiveRecord::Migration
+class AddImageResizeUserSetting < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE users ADD COLUMN always_resize_images BOOLEAN NOT NULL DEFAULT FALSE"
   end

--- a/db/migrate/029_add_safe_post_count_to_tags.rb
+++ b/db/migrate/029_add_safe_post_count_to_tags.rb
@@ -1,4 +1,4 @@
-class AddSafePostCountToTags < ActiveRecord::Migration
+class AddSafePostCountToTags < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE tags ADD COLUMN safe_post_count INTEGER NOT NULL DEFAULT 0"
     execute "UPDATE tags SET safe_post_count = (SELECT COUNT(*) FROM posts p, posts_tags pt WHERE p.id = pt.post_id AND pt.tag_id = tags.id AND p.rating = 's')"

--- a/db/migrate/030_add_invited_by_to_users.rb
+++ b/db/migrate/030_add_invited_by_to_users.rb
@@ -1,4 +1,4 @@
-class AddInvitedByToUsers < ActiveRecord::Migration
+class AddInvitedByToUsers < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE users ADD COLUMN invited_by INTEGER"
   end

--- a/db/migrate/031_create_news_updates.rb
+++ b/db/migrate/031_create_news_updates.rb
@@ -1,4 +1,4 @@
-class CreateNewsUpdates < ActiveRecord::Migration
+class CreateNewsUpdates < ActiveRecord::Migration[5.1]
   def self.up
     execute <<-EOS
       CREATE TABLE news_updates (

--- a/db/migrate/032_forum_posts_fix_creator_id.rb
+++ b/db/migrate/032_forum_posts_fix_creator_id.rb
@@ -1,4 +1,4 @@
-class ForumPostsFixCreatorId < ActiveRecord::Migration
+class ForumPostsFixCreatorId < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table forum_posts drop constraint forum_posts_creator_id_fkey"
     execute "alter table forum_posts alter column creator_id drop not null"

--- a/db/migrate/033_posts_add_is_flagged.rb
+++ b/db/migrate/033_posts_add_is_flagged.rb
@@ -1,4 +1,4 @@
-class PostsAddIsFlagged < ActiveRecord::Migration
+class PostsAddIsFlagged < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table posts add column is_flagged boolean not null default false"
   end

--- a/db/migrate/034_pools_create.rb
+++ b/db/migrate/034_pools_create.rb
@@ -1,4 +1,4 @@
-class PoolsCreate < ActiveRecord::Migration
+class PoolsCreate < ActiveRecord::Migration[5.1]
   def self.up
     ActiveRecord::Base.transaction do
       execute <<-EOS

--- a/db/migrate/035_users_rename_password.rb
+++ b/db/migrate/035_users_rename_password.rb
@@ -1,4 +1,4 @@
-class UsersRenamePassword < ActiveRecord::Migration
+class UsersRenamePassword < ActiveRecord::Migration[5.1]
   def self.up
     rename_column :users, :password, :password_hash
   end

--- a/db/migrate/036_users_update_level.rb
+++ b/db/migrate/036_users_update_level.rb
@@ -1,4 +1,4 @@
-class UsersUpdateLevel < ActiveRecord::Migration
+class UsersUpdateLevel < ActiveRecord::Migration[5.1]
   def self.up
     execute "update users set level = 3 where level = 2"
   end

--- a/db/migrate/037_users_add_created_at.rb
+++ b/db/migrate/037_users_add_created_at.rb
@@ -1,4 +1,4 @@
-class UsersAddCreatedAt < ActiveRecord::Migration
+class UsersAddCreatedAt < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE users ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT now()"
   end

--- a/db/migrate/038_favorites_add_created_at.rb
+++ b/db/migrate/038_favorites_add_created_at.rb
@@ -1,4 +1,4 @@
-class FavoritesAddCreatedAt < ActiveRecord::Migration
+class FavoritesAddCreatedAt < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table favorites add column created_at timestamp not null default now()"
     execute "update favorites set created_at = (select created_at from posts where id = favorites.post_id)"

--- a/db/migrate/039_posts_add_is_pending.rb
+++ b/db/migrate/039_posts_add_is_pending.rb
@@ -1,4 +1,4 @@
-class PostsAddIsPending < ActiveRecord::Migration
+class PostsAddIsPending < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table posts add column is_pending boolean not null default false"
   end

--- a/db/migrate/040_cleanup.rb
+++ b/db/migrate/040_cleanup.rb
@@ -1,4 +1,4 @@
-class Cleanup < ActiveRecord::Migration
+class Cleanup < ActiveRecord::Migration[5.1]
   def self.up
     remove_column :forum_posts, :reply_count
     remove_column :users, :user_blacklist

--- a/db/migrate/041_users_add_ip_addr.rb
+++ b/db/migrate/041_users_add_ip_addr.rb
@@ -1,4 +1,4 @@
-class UsersAddIpAddr < ActiveRecord::Migration
+class UsersAddIpAddr < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table users add column ip_addr text not null default ''"
     execute "alter table users add column last_logged_in_at timestamp not null default now()"

--- a/db/migrate/042_note_versions_add_index_on_user_id.rb
+++ b/db/migrate/042_note_versions_add_index_on_user_id.rb
@@ -1,4 +1,4 @@
-class NoteVersionsAddIndexOnUserId < ActiveRecord::Migration
+class NoteVersionsAddIndexOnUserId < ActiveRecord::Migration[5.1]
   def self.up
     add_index :note_versions, :user_id
   end

--- a/db/migrate/043_flagged_posts_create.rb
+++ b/db/migrate/043_flagged_posts_create.rb
@@ -1,4 +1,4 @@
-class FlaggedPostsCreate < ActiveRecord::Migration
+class FlaggedPostsCreate < ActiveRecord::Migration[5.1]
   def self.up
     execute <<-EOS
       create table flagged_posts (

--- a/db/migrate/044_forum_add_is_locked.rb
+++ b/db/migrate/044_forum_add_is_locked.rb
@@ -1,4 +1,4 @@
-class ForumAddIsLocked < ActiveRecord::Migration
+class ForumAddIsLocked < ActiveRecord::Migration[5.1]
   def self.up
     transaction do
       add_column :forum_posts, :is_locked, :boolean, :null => false, :default => false

--- a/db/migrate/045_user_records_create.rb
+++ b/db/migrate/045_user_records_create.rb
@@ -1,4 +1,4 @@
-class UserRecordsCreate < ActiveRecord::Migration
+class UserRecordsCreate < ActiveRecord::Migration[5.1]
   def self.up
     execute <<-EOS
       create table user_records (

--- a/db/migrate/046_posts_tags_add_foreign_keys.rb
+++ b/db/migrate/046_posts_tags_add_foreign_keys.rb
@@ -1,4 +1,4 @@
-class PostsTagsAddForeignKeys < ActiveRecord::Migration
+class PostsTagsAddForeignKeys < ActiveRecord::Migration[5.1]
   def self.up
     transaction do
       execute "update tags set post_count = (select count(*) from posts_tags pt where pt.tag_id = tags.id)"

--- a/db/migrate/047_posts_add_parent_id.rb
+++ b/db/migrate/047_posts_add_parent_id.rb
@@ -1,4 +1,4 @@
-class PostsAddParentId < ActiveRecord::Migration
+class PostsAddParentId < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table posts add column parent_id integer references posts on delete set null"
     execute "create index idx_posts_parent_id on posts (parent_id) where parent_id is not null"

--- a/db/migrate/048_posts_add_has_children.rb
+++ b/db/migrate/048_posts_add_has_children.rb
@@ -1,4 +1,4 @@
-class PostsAddHasChildren < ActiveRecord::Migration
+class PostsAddHasChildren < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table posts add column has_children boolean not null default false"
   end

--- a/db/migrate/049_flagged_posts_drop_foreign_key.rb
+++ b/db/migrate/049_flagged_posts_drop_foreign_key.rb
@@ -1,4 +1,4 @@
-class FlaggedPostsDropForeignKey < ActiveRecord::Migration
+class FlaggedPostsDropForeignKey < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table flagged_posts drop constraint flagged_posts_post_id_fkey"
   end

--- a/db/migrate/051_posts_drop_has_children.rb
+++ b/db/migrate/051_posts_drop_has_children.rb
@@ -1,4 +1,4 @@
-class PostsDropHasChildren < ActiveRecord::Migration
+class PostsDropHasChildren < ActiveRecord::Migration[5.1]
   def self.up
     # execute "alter table posts drop column has_children"
   end

--- a/db/migrate/052_flagged_posts_add_user_id.rb
+++ b/db/migrate/052_flagged_posts_add_user_id.rb
@@ -1,4 +1,4 @@
-class FlaggedPostsAddUserId < ActiveRecord::Migration
+class FlaggedPostsAddUserId < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table flagged_posts add column user_id integer references users on delete cascade"
     execute "alter table flagged_posts add column is_resolved boolean not null default false"

--- a/db/migrate/053_convert_ip_text_to_inet.rb
+++ b/db/migrate/053_convert_ip_text_to_inet.rb
@@ -1,4 +1,4 @@
-class ConvertIpTextToInet < ActiveRecord::Migration
+class ConvertIpTextToInet < ActiveRecord::Migration[5.1]
   def self.up
     transaction do
       execute "update posts set last_voter_ip = null where last_voter_ip = ''"

--- a/db/migrate/054_posts_add_status.rb
+++ b/db/migrate/054_posts_add_status.rb
@@ -1,4 +1,4 @@
-class PostsAddStatus < ActiveRecord::Migration
+class PostsAddStatus < ActiveRecord::Migration[5.1]
   def self.up
     transaction do
       execute "create type post_status as enum ('deleted', 'flagged', 'pending', 'active')"

--- a/db/migrate/055_add_full_text_search.rb
+++ b/db/migrate/055_add_full_text_search.rb
@@ -1,4 +1,4 @@
-class AddFullTextSearch < ActiveRecord::Migration
+class AddFullTextSearch < ActiveRecord::Migration[5.1]
   def self.up
     transaction do
       execute "alter table notes add column text_search_index tsvector"

--- a/db/migrate/056_add_text_search_to_versions.rb
+++ b/db/migrate/056_add_text_search_to_versions.rb
@@ -1,4 +1,4 @@
-class AddTextSearchToVersions < ActiveRecord::Migration
+class AddTextSearchToVersions < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table note_versions add column text_search_index tsvector"
     execute "alter table wiki_page_versions add column text_search_index tsvector"

--- a/db/migrate/057_drop_post_count_triggers.rb
+++ b/db/migrate/057_drop_post_count_triggers.rb
@@ -1,4 +1,4 @@
-class DropPostCountTriggers < ActiveRecord::Migration
+class DropPostCountTriggers < ActiveRecord::Migration[5.1]
   def self.up
     execute "drop trigger trg_posts__insert on posts"
     execute "drop trigger trg_posts_delete on posts"

--- a/db/migrate/058_remove_notes_from_artists.rb
+++ b/db/migrate/058_remove_notes_from_artists.rb
@@ -1,4 +1,4 @@
-class RemoveNotesFromArtists < ActiveRecord::Migration
+class RemoveNotesFromArtists < ActiveRecord::Migration[5.1]
   def self.up
     Artist.find(:all, :conditions => ["notes <> '' and notes is not null"]).each do |artist|
       page = WikiPage.find_by_title(artist.name)

--- a/db/migrate/059_create_dmails.rb
+++ b/db/migrate/059_create_dmails.rb
@@ -1,4 +1,4 @@
-class CreateDmails < ActiveRecord::Migration
+class CreateDmails < ActiveRecord::Migration[5.1]
   def self.up
     transaction do
       create_table :dmails do |t|

--- a/db/migrate/060_add_receive_mails_to_users.rb
+++ b/db/migrate/060_add_receive_mails_to_users.rb
@@ -1,4 +1,4 @@
-class AddReceiveMailsToUsers < ActiveRecord::Migration
+class AddReceiveMailsToUsers < ActiveRecord::Migration[5.1]
   def self.up
     add_column :users, :receive_dmails, :boolean, :default => false, :null => false
   end

--- a/db/migrate/061_enhance_dmails.rb
+++ b/db/migrate/061_enhance_dmails.rb
@@ -1,4 +1,4 @@
-class EnhanceDmails < ActiveRecord::Migration
+class EnhanceDmails < ActiveRecord::Migration[5.1]
   def self.up
     add_column :dmails, :parent_id, :integer
     add_foreign_key :dmails, :parent_id, :dmails, :id

--- a/db/migrate/062_create_bans.rb
+++ b/db/migrate/062_create_bans.rb
@@ -1,4 +1,4 @@
-class CreateBans < ActiveRecord::Migration
+class CreateBans < ActiveRecord::Migration[5.1]
   def self.up
     create_table :bans do |t|
       t.column :user_id, :integer, :null => false

--- a/db/migrate/063_add_blacklisted_tags_to_users.rb
+++ b/db/migrate/063_add_blacklisted_tags_to_users.rb
@@ -1,4 +1,4 @@
-class AddBlacklistedTagsToUsers < ActiveRecord::Migration
+class AddBlacklistedTagsToUsers < ActiveRecord::Migration[5.1]
   def self.up
     add_column :users, :blacklisted_tags, :text, :null => false, :default => ""
   end

--- a/db/migrate/064_remove_neighbor_constraints.rb
+++ b/db/migrate/064_remove_neighbor_constraints.rb
@@ -1,4 +1,4 @@
-class RemoveNeighborConstraints < ActiveRecord::Migration
+class RemoveNeighborConstraints < ActiveRecord::Migration[5.1]
   def self.up
     remove_foreign_key :posts, :posts_next_post_id_fkey
     remove_foreign_key :posts, :posts_prev_post_id_fkey

--- a/db/migrate/065_remove_yaml.rb
+++ b/db/migrate/065_remove_yaml.rb
@@ -1,6 +1,6 @@
 require "yaml"
 
-class RemoveYaml < ActiveRecord::Migration
+class RemoveYaml < ActiveRecord::Migration[5.1]
   def self.up
     Tag.find(:all).each do |tag|
       mapping = YAML.load(tag.cached_related)

--- a/db/migrate/066_fix_user_levels.rb
+++ b/db/migrate/066_fix_user_levels.rb
@@ -1,4 +1,4 @@
-class FixUserLevels < ActiveRecord::Migration
+class FixUserLevels < ActiveRecord::Migration[5.1]
   def self.up
     execute("UPDATE users SET level = 50 WHERE level = 20")
     execute("UPDATE users SET level = 40 WHERE level = 10")

--- a/db/migrate/067_create_artist_urls.rb
+++ b/db/migrate/067_create_artist_urls.rb
@@ -1,7 +1,7 @@
 class Artist < ActiveRecord::Base
 end
 
-class CreateArtistUrls < ActiveRecord::Migration
+class CreateArtistUrls < ActiveRecord::Migration[5.1]
   def self.up
     create_table :artist_urls do |t|
       t.column :artist_id, :integer, :null => false

--- a/db/migrate/068_add_pixiv_to_artists.rb
+++ b/db/migrate/068_add_pixiv_to_artists.rb
@@ -1,4 +1,4 @@
-class AddPixivToArtists < ActiveRecord::Migration
+class AddPixivToArtists < ActiveRecord::Migration[5.1]
   def self.up
     add_column :artists, :pixiv_id, :integer
     add_index :artists, :pixiv_id

--- a/db/migrate/069_clean_up_users.rb
+++ b/db/migrate/069_clean_up_users.rb
@@ -1,4 +1,4 @@
-class CleanUpUsers < ActiveRecord::Migration
+class CleanUpUsers < ActiveRecord::Migration[5.1]
   def self.up
     remove_column :users, :ip_addr
     remove_column :users, :tag_blacklist

--- a/db/migrate/070_add_approved_by_to_posts.rb
+++ b/db/migrate/070_add_approved_by_to_posts.rb
@@ -1,4 +1,4 @@
-class AddApprovedByToPosts < ActiveRecord::Migration
+class AddApprovedByToPosts < ActiveRecord::Migration[5.1]
   def self.up
     add_column :posts, :approved_by, :integer
     add_foreign_key :posts, :approved_by, :users, :id

--- a/db/migrate/071_create_flagged_post_details.rb
+++ b/db/migrate/071_create_flagged_post_details.rb
@@ -4,7 +4,7 @@ end
 class FlaggedPostDetail < ActiveRecord::Base
 end
 
-class CreateFlaggedPostDetails < ActiveRecord::Migration
+class CreateFlaggedPostDetails < ActiveRecord::Migration[5.1]
   def self.up
     remove_column :posts, :approved_by
 

--- a/db/migrate/072_add_reason_to_aliases_and_implications.rb
+++ b/db/migrate/072_add_reason_to_aliases_and_implications.rb
@@ -1,4 +1,4 @@
-class AddReasonToAliasesAndImplications < ActiveRecord::Migration
+class AddReasonToAliasesAndImplications < ActiveRecord::Migration[5.1]
   def self.up
     add_column :tag_aliases, :reason, :text, :null => false, :default => ""
     add_column :tag_implications, :reason, :text, :null => false, :default => ""

--- a/db/migrate/073_fix_flagged_post_details_foreign_keys.rb
+++ b/db/migrate/073_fix_flagged_post_details_foreign_keys.rb
@@ -1,4 +1,4 @@
-class FixFlaggedPostDetailsForeignKeys < ActiveRecord::Migration
+class FixFlaggedPostDetailsForeignKeys < ActiveRecord::Migration[5.1]
   def self.up
     remove_foreign_key :flagged_post_details, :flagged_post_details_post_id_fkey
     remove_foreign_key :flagged_post_details, :flagged_post_details_user_id_fkey

--- a/db/migrate/074_remove_pixiv_field.rb
+++ b/db/migrate/074_remove_pixiv_field.rb
@@ -1,4 +1,4 @@
-class RemovePixivField < ActiveRecord::Migration
+class RemovePixivField < ActiveRecord::Migration[5.1]
   def self.up
     remove_column :artists, :pixiv_id
   end

--- a/db/migrate/075_add_sample_columns.rb
+++ b/db/migrate/075_add_sample_columns.rb
@@ -1,4 +1,4 @@
-class AddSampleColumns < ActiveRecord::Migration
+class AddSampleColumns < ActiveRecord::Migration[5.1]
   def self.up
     add_column :posts, :sample_width, :integer
     add_column :posts, :sample_height, :integer

--- a/db/migrate/076_create_user_blacklisted_tags.rb
+++ b/db/migrate/076_create_user_blacklisted_tags.rb
@@ -4,7 +4,7 @@ end
 class UserBlacklistedTags < ActiveRecord::Base
 end
 
-class CreateUserBlacklistedTags < ActiveRecord::Migration
+class CreateUserBlacklistedTags < ActiveRecord::Migration[5.1]
   def self.up
     create_table :user_blacklisted_tags do |t|
       t.column :user_id, :integer, :null => false

--- a/db/migrate/077_create_server_keys.rb
+++ b/db/migrate/077_create_server_keys.rb
@@ -1,6 +1,6 @@
 require "digest/sha1"
 
-class CreateServerKeys < ActiveRecord::Migration
+class CreateServerKeys < ActiveRecord::Migration[5.1]
   def self.up
     create_table :server_keys do |t|
       t.column :name, :string, :null => false

--- a/db/migrate/078_add_neighbors_to_pools.rb
+++ b/db/migrate/078_add_neighbors_to_pools.rb
@@ -7,7 +7,7 @@ class Pool < ActiveRecord::Base
   has_many :pool_posts, :class_name => "PoolPost", :order => "sequence"
 end
 
-class AddNeighborsToPools < ActiveRecord::Migration
+class AddNeighborsToPools < ActiveRecord::Migration[5.1]
   def self.up
     add_column :pools_posts, :next_post_id, :integer
     add_column :pools_posts, :prev_post_id, :integer

--- a/db/migrate/079_create_post_change_seq.rb
+++ b/db/migrate/079_create_post_change_seq.rb
@@ -1,4 +1,4 @@
-class CreatePostChangeSeq < ActiveRecord::Migration
+class CreatePostChangeSeq < ActiveRecord::Migration[5.1]
   def self.up
     execute "CREATE SEQUENCE post_change_seq INCREMENT BY 1 CACHE 10;"
     execute "ALTER TABLE posts ADD COLUMN change_seq INTEGER DEFAULT nextval('post_change_seq'::regclass) NOT NULL;"

--- a/db/migrate/080_remove_neighbor_fields_from_posts.rb
+++ b/db/migrate/080_remove_neighbor_fields_from_posts.rb
@@ -1,4 +1,4 @@
-class RemoveNeighborFieldsFromPosts < ActiveRecord::Migration
+class RemoveNeighborFieldsFromPosts < ActiveRecord::Migration[5.1]
   def self.up
     remove_column :posts, :next_post_id
     remove_column :posts, :prev_post_id

--- a/db/migrate/081_disable_change_seq_cache.rb
+++ b/db/migrate/081_disable_change_seq_cache.rb
@@ -1,4 +1,4 @@
-class DisableChangeSeqCache < ActiveRecord::Migration
+class DisableChangeSeqCache < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER SEQUENCE post_change_seq CACHE 1"
     execute "ALTER TABLE posts ALTER COLUMN change_seq DROP NOT NULL"

--- a/db/migrate/082_add_post_votes.rb
+++ b/db/migrate/082_add_post_votes.rb
@@ -1,6 +1,6 @@
 require "activerecord.rb"
 
-class AddPostVotes < ActiveRecord::Migration
+class AddPostVotes < ActiveRecord::Migration[5.1]
   def self.up
     create_table :post_votes do |t|
       t.column :user_id, :integer, :null => false

--- a/db/migrate/083_add_user_id_to_aliases_and_implicatons.rb
+++ b/db/migrate/083_add_user_id_to_aliases_and_implicatons.rb
@@ -1,4 +1,4 @@
-class AddUserIdToAliasesAndImplicatons < ActiveRecord::Migration
+class AddUserIdToAliasesAndImplicatons < ActiveRecord::Migration[5.1]
   def self.up
     add_column "tag_aliases", "creator_id", :integer
     add_column "tag_implications", "creator_id", :integer

--- a/db/migrate/084_add_user_id_index_on_post_tag_histories.rb
+++ b/db/migrate/084_add_user_id_index_on_post_tag_histories.rb
@@ -1,4 +1,4 @@
-class AddUserIdIndexOnPostTagHistories < ActiveRecord::Migration
+class AddUserIdIndexOnPostTagHistories < ActiveRecord::Migration[5.1]
   def self.up
     add_index "post_tag_histories", "user_id"
   end

--- a/db/migrate/085_revert_post_votes.rb
+++ b/db/migrate/085_revert_post_votes.rb
@@ -1,4 +1,4 @@
-class RevertPostVotes < ActiveRecord::Migration
+class RevertPostVotes < ActiveRecord::Migration[5.1]
   # bad change disabled
   def self.down
   end

--- a/db/migrate/086_add_is_active_field_to_pools.rb
+++ b/db/migrate/086_add_is_active_field_to_pools.rb
@@ -1,4 +1,4 @@
-class AddIsActiveFieldToPools < ActiveRecord::Migration
+class AddIsActiveFieldToPools < ActiveRecord::Migration[5.1]
   def self.up
     add_column :pools, :is_active, :boolean, :null => false, :default => true
   end

--- a/db/migrate/087_add_dimensions_index_on_posts.rb
+++ b/db/migrate/087_add_dimensions_index_on_posts.rb
@@ -1,4 +1,4 @@
-class AddDimensionsIndexOnPosts < ActiveRecord::Migration
+class AddDimensionsIndexOnPosts < ActiveRecord::Migration[5.1]
   def self.up
     add_index "posts", "width"
     add_index "posts", "height"

--- a/db/migrate/088_add_approver_id_to_posts.rb
+++ b/db/migrate/088_add_approver_id_to_posts.rb
@@ -1,4 +1,4 @@
-class AddApproverIdToPosts < ActiveRecord::Migration
+class AddApproverIdToPosts < ActiveRecord::Migration[5.1]
   def self.up
     add_column :posts, :approver_id, :integer
     add_foreign_key :posts, :approver_id, :users, :id, :on_delete => :set_null

--- a/db/migrate/089_add_index_on_post_source.rb
+++ b/db/migrate/089_add_index_on_post_source.rb
@@ -1,4 +1,4 @@
-class AddIndexOnPostSource < ActiveRecord::Migration
+class AddIndexOnPostSource < ActiveRecord::Migration[5.1]
   def self.up
     add_index :posts, :source
   end

--- a/db/migrate/090_add_rating_to_tag_history.rb
+++ b/db/migrate/090_add_rating_to_tag_history.rb
@@ -1,4 +1,4 @@
-class AddRatingToTagHistory < ActiveRecord::Migration
+class AddRatingToTagHistory < ActiveRecord::Migration[5.1]
   def self.up
     #    execute "ALTER TABLE post_tag_histories ADD COLUMN rating CHARACTER"
   end

--- a/db/migrate/09142010220946_add_fts_to_pools.rb
+++ b/db/migrate/09142010220946_add_fts_to_pools.rb
@@ -1,4 +1,4 @@
-class AddFtsToPools < ActiveRecord::Migration
+class AddFtsToPools < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE pools ADD COLUMN search_index tsvector"
 

--- a/db/migrate/091_migrate_users_to_contributor.rb
+++ b/db/migrate/091_migrate_users_to_contributor.rb
@@ -1,4 +1,4 @@
-class MigrateUsersToContributor < ActiveRecord::Migration
+class MigrateUsersToContributor < ActiveRecord::Migration[5.1]
   def self.up
     User.find(:all, :conditions => "level = 30").each do |user|
       post_count = Post.count(:conditions => ["user_id = ? AND status <> 'deleted'", user.id])

--- a/db/migrate/092_create_job_tasks.rb
+++ b/db/migrate/092_create_job_tasks.rb
@@ -1,4 +1,4 @@
-class CreateJobTasks < ActiveRecord::Migration
+class CreateJobTasks < ActiveRecord::Migration[5.1]
   def self.up
     create_table :job_tasks do |t|
       t.column :task_type, :string, :null => false

--- a/db/migrate/093_change_type_of_data_in_job_tasks.rb
+++ b/db/migrate/093_change_type_of_data_in_job_tasks.rb
@@ -1,4 +1,4 @@
-class ChangeTypeOfDataInJobTasks < ActiveRecord::Migration
+class ChangeTypeOfDataInJobTasks < ActiveRecord::Migration[5.1]
   def self.up
     remove_column :job_tasks, :data_as_json
     add_column :job_tasks, :data_as_json, :text, :null => false, :default => "{}"

--- a/db/migrate/094_favorite_tags.rb
+++ b/db/migrate/094_favorite_tags.rb
@@ -1,4 +1,4 @@
-class FavoriteTags < ActiveRecord::Migration
+class FavoriteTags < ActiveRecord::Migration[5.1]
   def self.up
     create_table :favorite_tags do |t|
       t.column :user_id, :integer, :null => false

--- a/db/migrate/095_add_repeat_count_to_job_tasks.rb
+++ b/db/migrate/095_add_repeat_count_to_job_tasks.rb
@@ -1,4 +1,4 @@
-class AddRepeatCountToJobTasks < ActiveRecord::Migration
+class AddRepeatCountToJobTasks < ActiveRecord::Migration[5.1]
   def self.up
     add_column :job_tasks, :repeat_count, :integer, :null => false, :default => 0
     JobTask.create(:task_type => "calculate_favorite_tags", :status => "pending", :repeat_count => -1)

--- a/db/migrate/096_create_advertisements.rb
+++ b/db/migrate/096_create_advertisements.rb
@@ -1,4 +1,4 @@
-class CreateAdvertisements < ActiveRecord::Migration
+class CreateAdvertisements < ActiveRecord::Migration[5.1]
   def self.up
     create_table :advertisements do |t|
       t.column :image_url, :string, :null => false

--- a/db/migrate/20080901000000_no_really_add_post_votes.rb
+++ b/db/migrate/20080901000000_no_really_add_post_votes.rb
@@ -4,7 +4,7 @@ require "activerecord.rb"
 # migrated with our migrations, leave things alone; we're all set.  If the site was
 # migrated with upstream 085, the post_votes table is missing and needs to be
 # recreated.
-class NoReallyAddPostVotes < ActiveRecord::Migration
+class NoReallyAddPostVotes < ActiveRecord::Migration[5.1]
   def self.up
     return if select_value_sql "SELECT 1 FROM information_schema.tables WHERE table_name = 'post_votes'"
 

--- a/db/migrate/20080927145957_make_wiki_titles_unique.rb
+++ b/db/migrate/20080927145957_make_wiki_titles_unique.rb
@@ -1,4 +1,4 @@
-class MakeWikiTitlesUnique < ActiveRecord::Migration
+class MakeWikiTitlesUnique < ActiveRecord::Migration[5.1]
   def self.up
     execute "DROP INDEX idx_wiki_pages__title"
     execute "CREATE UNIQUE INDEX idx_wiki_pages__title ON wiki_pages (title)"

--- a/db/migrate/20081015004825_create_user_log.rb
+++ b/db/migrate/20081015004825_create_user_log.rb
@@ -1,4 +1,4 @@
-class CreateUserLog < ActiveRecord::Migration
+class CreateUserLog < ActiveRecord::Migration[5.1]
   def self.up
     execute <<-EOS
           CREATE TABLE user_logs (

--- a/db/migrate/20081015004855_add_random_to_posts.rb
+++ b/db/migrate/20081015004855_add_random_to_posts.rb
@@ -1,4 +1,4 @@
-class AddRandomToPosts < ActiveRecord::Migration
+class AddRandomToPosts < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE posts ADD COLUMN random REAL DEFAULT RANDOM() NOT NULL;"
     add_index :posts, :random

--- a/db/migrate/20081015004938_convert_favorites_to_votes.rb
+++ b/db/migrate/20081015004938_convert_favorites_to_votes.rb
@@ -1,6 +1,6 @@
 require "post"
 
-class ConvertFavoritesToVotes < ActiveRecord::Migration
+class ConvertFavoritesToVotes < ActiveRecord::Migration[5.1]
   def self.up
     # Favorites doesn't have a dupe constraint and post_votes does, so make sure
     # there are no dupes before we copy.

--- a/db/migrate/20081015005018_create_ip_bans.rb
+++ b/db/migrate/20081015005018_create_ip_bans.rb
@@ -1,4 +1,4 @@
-class CreateIpBans < ActiveRecord::Migration
+class CreateIpBans < ActiveRecord::Migration[5.1]
   def self.up
     execute <<-EOS
       CREATE TABLE ip_bans (

--- a/db/migrate/20081015005051_add_avatar_to_user.rb
+++ b/db/migrate/20081015005051_add_avatar_to_user.rb
@@ -1,4 +1,4 @@
-class AddAvatarToUser < ActiveRecord::Migration
+class AddAvatarToUser < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE users ADD COLUMN avatar_post_id INTEGER"
     execute "ALTER TABLE users ADD COLUMN avatar_width REAL"

--- a/db/migrate/20081015005124_add_last_comment_read_at_to_user.rb
+++ b/db/migrate/20081015005124_add_last_comment_read_at_to_user.rb
@@ -1,4 +1,4 @@
-class AddLastCommentReadAtToUser < ActiveRecord::Migration
+class AddLastCommentReadAtToUser < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table users add column last_comment_read_at timestamp not null default '1960-01-01'"
   end

--- a/db/migrate/20081015005201_add_history_table.rb
+++ b/db/migrate/20081015005201_add_history_table.rb
@@ -1,4 +1,4 @@
-class AddHistoryTable < ActiveRecord::Migration
+class AddHistoryTable < ActiveRecord::Migration[5.1]
   def self.up
     execute <<-EOS
       CREATE TABLE history_changes (

--- a/db/migrate/20081015005919_import_post_tag_histories.rb
+++ b/db/migrate/20081015005919_import_post_tag_histories.rb
@@ -1,4 +1,4 @@
-class ImportPostTagHistories < ActiveRecord::Migration
+class ImportPostTagHistories < ActiveRecord::Migration[5.1]
   def self.up
     ActiveRecord::Base.import_post_tag_history
   end

--- a/db/migrate/20081015010657_update_histories.rb
+++ b/db/migrate/20081015010657_update_histories.rb
@@ -1,4 +1,4 @@
-class UpdateHistories < ActiveRecord::Migration
+class UpdateHistories < ActiveRecord::Migration[5.1]
   def self.up
     ActiveRecord::Base.update_all_versioned_tables
   end

--- a/db/migrate/20081016002814_post_source_not_null.rb
+++ b/db/migrate/20081016002814_post_source_not_null.rb
@@ -1,4 +1,4 @@
-class PostSourceNotNull < ActiveRecord::Migration
+class PostSourceNotNull < ActiveRecord::Migration[5.1]
   def self.up
     execute "UPDATE posts SET source='' WHERE source IS NULL"
     execute "UPDATE history_changes SET value='' WHERE table_name='posts' AND field='source' AND value IS NULL"

--- a/db/migrate/20081018175545_post_source_default.rb
+++ b/db/migrate/20081018175545_post_source_default.rb
@@ -1,4 +1,4 @@
-class PostSourceDefault < ActiveRecord::Migration
+class PostSourceDefault < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE posts ALTER COLUMN source SET DEFAULT ''"
   end

--- a/db/migrate/20081023224739_add_mirror_posts_to_job_tasks.rb
+++ b/db/migrate/20081023224739_add_mirror_posts_to_job_tasks.rb
@@ -1,4 +1,4 @@
-class AddMirrorPostsToJobTasks < ActiveRecord::Migration
+class AddMirrorPostsToJobTasks < ActiveRecord::Migration[5.1]
   def self.up
     JobTask.create(:task_type => "upload_posts_to_mirrors", :status => "pending", :repeat_count => -1)
   end

--- a/db/migrate/20081024083115_pools_default_to_public.rb
+++ b/db/migrate/20081024083115_pools_default_to_public.rb
@@ -1,4 +1,4 @@
-class PoolsDefaultToPublic < ActiveRecord::Migration
+class PoolsDefaultToPublic < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE pools ALTER COLUMN is_public SET DEFAULT TRUE"
   end

--- a/db/migrate/20081024223856_add_old_level_to_bans.rb
+++ b/db/migrate/20081024223856_add_old_level_to_bans.rb
@@ -1,4 +1,4 @@
-class AddOldLevelToBans < ActiveRecord::Migration
+class AddOldLevelToBans < ActiveRecord::Migration[5.1]
   def self.up
     add_column :bans, :old_level, :integer
   end

--- a/db/migrate/20081025222424_add_fts_to_comments.rb
+++ b/db/migrate/20081025222424_add_fts_to_comments.rb
@@ -1,4 +1,4 @@
-class AddFtsToComments < ActiveRecord::Migration
+class AddFtsToComments < ActiveRecord::Migration[5.1]
   def self.up
     execute "alter table comments add column text_search_index tsvector"
     execute "update comments set text_search_index = to_tsvector('english', body)"

--- a/db/migrate/20081105030832_add_periodic_maintenance_to_job_tasks.rb
+++ b/db/migrate/20081105030832_add_periodic_maintenance_to_job_tasks.rb
@@ -1,4 +1,4 @@
-class AddPeriodicMaintenanceToJobTasks < ActiveRecord::Migration
+class AddPeriodicMaintenanceToJobTasks < ActiveRecord::Migration[5.1]
   def self.up
     JobTask.create(:task_type => "periodic_maintenance", :status => "pending", :repeat_count => -1)
   end

--- a/db/migrate/20081122055610_add_last_deleted_post_seen_at.rb
+++ b/db/migrate/20081122055610_add_last_deleted_post_seen_at.rb
@@ -1,4 +1,4 @@
-class AddLastDeletedPostSeenAt < ActiveRecord::Migration
+class AddLastDeletedPostSeenAt < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE users ADD COLUMN last_deleted_post_seen_at timestamp not null default '1960-01-01'"
     add_index :flagged_post_details, :created_at

--- a/db/migrate/20081130190723_add_file_size_to_posts.rb
+++ b/db/migrate/20081130190723_add_file_size_to_posts.rb
@@ -1,4 +1,4 @@
-class AddFileSizeToPosts < ActiveRecord::Migration
+class AddFileSizeToPosts < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE posts ADD COLUMN file_size INTEGER NOT NULL DEFAULT 0"
     execute "ALTER TABLE posts ADD COLUMN sample_size INTEGER NOT NULL DEFAULT 0"

--- a/db/migrate/20081130191226_add_crc32_to_posts.rb
+++ b/db/migrate/20081130191226_add_crc32_to_posts.rb
@@ -1,4 +1,4 @@
-class AddCrc32ToPosts < ActiveRecord::Migration
+class AddCrc32ToPosts < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE posts ADD COLUMN crc32 BIGINT"
     execute "ALTER TABLE posts ADD COLUMN sample_crc32 BIGINT"

--- a/db/migrate/20081203035506_add_is_held_to_posts.rb
+++ b/db/migrate/20081203035506_add_is_held_to_posts.rb
@@ -1,4 +1,4 @@
-class AddIsHeldToPosts < ActiveRecord::Migration
+class AddIsHeldToPosts < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE posts ADD COLUMN is_held BOOLEAN NOT NULL DEFAULT FALSE"
     execute "ALTER TABLE posts ADD COLUMN index_timestamp TIMESTAMP NOT NULL DEFAULT now()"

--- a/db/migrate/20081204062728_add_shown_to_posts.rb
+++ b/db/migrate/20081204062728_add_shown_to_posts.rb
@@ -1,4 +1,4 @@
-class AddShownToPosts < ActiveRecord::Migration
+class AddShownToPosts < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE posts ADD COLUMN is_shown_in_index BOOLEAN NOT NULL DEFAULT TRUE"
     ActiveRecord::Base.update_versioned_tables Post, :attrs => [:is_shown_in_index]

--- a/db/migrate/20081205061033_add_natural_sort_to_pools.rb
+++ b/db/migrate/20081205061033_add_natural_sort_to_pools.rb
@@ -1,4 +1,4 @@
-class AddNaturalSortToPools < ActiveRecord::Migration
+class AddNaturalSortToPools < ActiveRecord::Migration[5.1]
   def self.up
     execute <<-EOS
       CREATE OR REPLACE FUNCTION nat_sort_pad(t text) RETURNS text IMMUTABLE AS $$

--- a/db/migrate/20081205072029_add_index_timestamp_index.rb
+++ b/db/migrate/20081205072029_add_index_timestamp_index.rb
@@ -1,4 +1,4 @@
-class AddIndexTimestampIndex < ActiveRecord::Migration
+class AddIndexTimestampIndex < ActiveRecord::Migration[5.1]
   def self.up
     add_index :posts, :index_timestamp
   end

--- a/db/migrate/20081208220020_pool_sequence_as_string.rb
+++ b/db/migrate/20081208220020_pool_sequence_as_string.rb
@@ -1,4 +1,4 @@
-class PoolSequenceAsString < ActiveRecord::Migration
+class PoolSequenceAsString < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE pools_posts ALTER COLUMN sequence TYPE TEXT"
     execute "CREATE INDEX idx_pools_posts__sequence_nat ON pools_posts (nat_sort(sequence))"

--- a/db/migrate/20081209221550_add_slave_pool_posts.rb
+++ b/db/migrate/20081209221550_add_slave_pool_posts.rb
@@ -1,6 +1,6 @@
 require "pool_post"
 
-class AddSlavePoolPosts < ActiveRecord::Migration
+class AddSlavePoolPosts < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE pools_posts ADD COLUMN master_id INTEGER REFERENCES pools_posts ON DELETE SET NULL"
     execute "ALTER TABLE pools_posts ADD COLUMN slave_id INTEGER REFERENCES pools_posts ON DELETE SET NULL"

--- a/db/migrate/20081210193125_add_index_history_changes_previous_id.rb
+++ b/db/migrate/20081210193125_add_index_history_changes_previous_id.rb
@@ -1,4 +1,4 @@
-class AddIndexHistoryChangesPreviousId < ActiveRecord::Migration
+class AddIndexHistoryChangesPreviousId < ActiveRecord::Migration[5.1]
   def self.up
     # We need an index on this for its ON DELETE SET NULL.
     add_index :history_changes, :previous_id

--- a/db/migrate/20090115234541_add_name_to_favorite_tags.rb
+++ b/db/migrate/20090115234541_add_name_to_favorite_tags.rb
@@ -1,4 +1,4 @@
-class AddNameToFavoriteTags < ActiveRecord::Migration
+class AddNameToFavoriteTags < ActiveRecord::Migration[5.1]
   def self.up
     add_foreign_key :favorite_tags, :user_id, :users, :id, :on_delete => :cascade
     add_column :favorite_tags, :name, :string, :null => false, :default => "General"

--- a/db/migrate/20090123212834_add_visible_on_profile_to_tag_subscriptions.rb
+++ b/db/migrate/20090123212834_add_visible_on_profile_to_tag_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddVisibleOnProfileToTagSubscriptions < ActiveRecord::Migration
+class AddVisibleOnProfileToTagSubscriptions < ActiveRecord::Migration[5.1]
   def self.up
     remove_index :favorite_tags, :name
     remove_index :favorite_tags, :user_id

--- a/db/migrate/20090208201752_add_full_text_index_on_post_tags.rb
+++ b/db/migrate/20090208201752_add_full_text_index_on_post_tags.rb
@@ -1,4 +1,4 @@
-class AddFullTextIndexOnPostTags < ActiveRecord::Migration
+class AddFullTextIndexOnPostTags < ActiveRecord::Migration[5.1]
   def self.up
     execute "SET statement_timeout = 0"
     execute "SET search_path = public"

--- a/db/migrate/20090215000207_add_inline_images.rb
+++ b/db/migrate/20090215000207_add_inline_images.rb
@@ -1,4 +1,4 @@
-class AddInlineImages < ActiveRecord::Migration
+class AddInlineImages < ActiveRecord::Migration[5.1]
   def self.up
     execute <<-EOS
       CREATE TABLE inlines (

--- a/db/migrate/20090903232732_update_post_text.rb
+++ b/db/migrate/20090903232732_update_post_text.rb
@@ -1,4 +1,4 @@
-class UpdatePostText < ActiveRecord::Migration
+class UpdatePostText < ActiveRecord::Migration[5.1]
   def self.up
     Comment.find(:all, :conditions => ["body ILIKE '%%<i>%%' OR body ILIKE '%%<b>%%'"]).each do |comment|
       comment.body = comment.body.gsub(/<i>/i, "[i]")

--- a/db/migrate/20091228170149_add_jpeg_columns.rb
+++ b/db/migrate/20091228170149_add_jpeg_columns.rb
@@ -1,4 +1,4 @@
-class AddJpegColumns < ActiveRecord::Migration
+class AddJpegColumns < ActiveRecord::Migration[5.1]
   def self.up
     add_column :posts, :jpeg_width, :integer
     add_column :posts, :jpeg_height, :integer

--- a/db/migrate/20100101225942_constrain_user_logs.rb
+++ b/db/migrate/20100101225942_constrain_user_logs.rb
@@ -1,4 +1,4 @@
-class ConstrainUserLogs < ActiveRecord::Migration
+class ConstrainUserLogs < ActiveRecord::Migration[5.1]
   def self.up
     execute <<-EOS
       CREATE TEMPORARY TABLE user_logs_new (

--- a/db/migrate/20100827031936_add_show_advanced_editing.rb
+++ b/db/migrate/20100827031936_add_show_advanced_editing.rb
@@ -1,4 +1,4 @@
-class AddShowAdvancedEditing < ActiveRecord::Migration
+class AddShowAdvancedEditing < ActiveRecord::Migration[5.1]
   def self.up
     add_column :users, :show_advanced_editing, :boolean, :default => false, :null => false
   end

--- a/db/migrate/20100831065951_add_batch_uploads.rb
+++ b/db/migrate/20100831065951_add_batch_uploads.rb
@@ -1,4 +1,4 @@
-class AddBatchUploads < ActiveRecord::Migration
+class AddBatchUploads < ActiveRecord::Migration[5.1]
   def self.up
     create_table :batch_uploads do |t|
       t.column :user_id, :integer, :null => false

--- a/db/migrate/20100903220234_remove_slave_pool_posts.rb
+++ b/db/migrate/20100903220234_remove_slave_pool_posts.rb
@@ -1,4 +1,4 @@
-class RemoveSlavePoolPosts < ActiveRecord::Migration
+class RemoveSlavePoolPosts < ActiveRecord::Migration[5.1]
   def self.up
     execute "ALTER TABLE pools_posts DROP COLUMN master_id"
     execute "ALTER TABLE pools_posts DROP COLUMN slave_id"

--- a/db/migrate/20100906054326_add_fts_to_history.rb
+++ b/db/migrate/20100906054326_add_fts_to_history.rb
@@ -1,4 +1,4 @@
-class AddFtsToHistory < ActiveRecord::Migration
+class AddFtsToHistory < ActiveRecord::Migration[5.1]
   def self.up
     execute "SET statement_timeout = 0"
     execute "SET search_path = public"

--- a/db/migrate/20100907042612_rename_favorites_job_task.rb
+++ b/db/migrate/20100907042612_rename_favorites_job_task.rb
@@ -1,4 +1,4 @@
-class RenameFavoritesJobTask < ActiveRecord::Migration
+class RenameFavoritesJobTask < ActiveRecord::Migration[5.1]
   def self.up
     execute "UPDATE job_tasks SET task_type='calculate_tag_subscriptions' WHERE task_type='calculate_favorite_tags'"
   end

--- a/db/migrate/20100907210915_include_note_body_in_history_fts.rb
+++ b/db/migrate/20100907210915_include_note_body_in_history_fts.rb
@@ -1,4 +1,4 @@
-class IncludeNoteBodyInHistoryFts < ActiveRecord::Migration
+class IncludeNoteBodyInHistoryFts < ActiveRecord::Migration[5.1]
   def self.up
     # For most value fields, just index it directly.  For cached_tags, index the changes compared
     # to the previous value.

--- a/db/migrate/20100907215811_add_aux_to_history.rb
+++ b/db/migrate/20100907215811_add_aux_to_history.rb
@@ -1,4 +1,4 @@
-class AddAuxToHistory < ActiveRecord::Migration
+class AddAuxToHistory < ActiveRecord::Migration[5.1]
   def self.up
     add_column :histories, :aux_as_json, :text
   end

--- a/db/migrate/20101011000658_add_comment_fragments.rb
+++ b/db/migrate/20101011000658_add_comment_fragments.rb
@@ -1,4 +1,4 @@
-class AddCommentFragments < ActiveRecord::Migration
+class AddCommentFragments < ActiveRecord::Migration[5.1]
   def self.up
     execute <<-EOS
       CREATE TABLE comment_fragments (

--- a/db/migrate/20101027013550_fix_fts_underscores.rb
+++ b/db/migrate/20101027013550_fix_fts_underscores.rb
@@ -1,4 +1,4 @@
-class  FixFtsUnderscores < ActiveRecord::Migration
+class  FixFtsUnderscores < ActiveRecord::Migration[5.1]
   def self.up
     execute """
       CREATE OR REPLACE FUNCTION replace_underscores(s varchar) RETURNS varchar IMMUTABLE AS $$

--- a/db/migrate/20101116221443_add_pools_default_to_user.rb
+++ b/db/migrate/20101116221443_add_pools_default_to_user.rb
@@ -1,4 +1,4 @@
-class AddPoolsDefaultToUser < ActiveRecord::Migration
+class AddPoolsDefaultToUser < ActiveRecord::Migration[5.1]
   def self.up
     add_column :users, :pool_browse_mode, :integer, :null => false, :default => 1
   end

--- a/db/migrate/20101212021821_add_post_frames.rb
+++ b/db/migrate/20101212021821_add_post_frames.rb
@@ -1,4 +1,4 @@
-class AddPostFrames < ActiveRecord::Migration
+class AddPostFrames < ActiveRecord::Migration[5.1]
   def self.up
     create_table :post_frames do |t|
       t.column :post_id, :integer, :null => false

--- a/db/migrate/20101218070942_add_browser_preference.rb
+++ b/db/migrate/20101218070942_add_browser_preference.rb
@@ -1,4 +1,4 @@
-class AddBrowserPreference < ActiveRecord::Migration
+class AddBrowserPreference < ActiveRecord::Migration[5.1]
   def self.up
     add_column :users, :use_browser, :boolean, :default => false, :null => false
   end

--- a/db/migrate/20110116202516_update_pool_count_triggers.rb
+++ b/db/migrate/20110116202516_update_pool_count_triggers.rb
@@ -1,4 +1,4 @@
-class UpdatePoolCountTriggers < ActiveRecord::Migration
+class UpdatePoolCountTriggers < ActiveRecord::Migration[5.1]
   def self.up
     execute <<-EOS
       CREATE OR REPLACE FUNCTION pools_posts_delete_trg() RETURNS "trigger" AS $$

--- a/db/migrate/20110228010717_flag_detail_optional_user_id.rb
+++ b/db/migrate/20110228010717_flag_detail_optional_user_id.rb
@@ -1,4 +1,4 @@
-class FlagDetailOptionalUserId < ActiveRecord::Migration
+class FlagDetailOptionalUserId < ActiveRecord::Migration[5.1]
   def self.up
     # If user_id on a flag is NULL, the flag was performed by the system and not a user.
     execute "ALTER TABLE flagged_post_details ALTER COLUMN user_id DROP NOT NULL"

--- a/db/migrate/20120331040429_fix_users_name_index.rb
+++ b/db/migrate/20120331040429_fix_users_name_index.rb
@@ -1,4 +1,4 @@
-class FixUsersNameIndex < ActiveRecord::Migration
+class FixUsersNameIndex < ActiveRecord::Migration[5.1]
   def self.up
     execute 'DROP INDEX "idx_users__name"'
     execute 'CREATE UNIQUE INDEX "idx_users__name" ON "users" (lower("name"))'

--- a/db/migrate/20120505130017_add_unique_index_to_posts_tag.rb
+++ b/db/migrate/20120505130017_add_unique_index_to_posts_tag.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexToPostsTag < ActiveRecord::Migration
+class AddUniqueIndexToPostsTag < ActiveRecord::Migration[5.1]
   def self.up
     add_index :posts_tags, [:post_id, :tag_id], :unique => true
   end

--- a/db/migrate/20120624121058_add_index_to_post_votes_updated_at.rb
+++ b/db/migrate/20120624121058_add_index_to_post_votes_updated_at.rb
@@ -1,4 +1,4 @@
-class AddIndexToPostVotesUpdatedAt < ActiveRecord::Migration
+class AddIndexToPostVotesUpdatedAt < ActiveRecord::Migration[5.1]
   def self.up
     add_index :post_votes, :updated_at
   end

--- a/db/migrate/20120723155345_fix_histories_column_name.rb
+++ b/db/migrate/20120723155345_fix_histories_column_name.rb
@@ -1,4 +1,4 @@
-class FixHistoriesColumnName < ActiveRecord::Migration
+class FixHistoriesColumnName < ActiveRecord::Migration[5.1]
   def change
     rename_column :history_changes, :field, :column_name
   end

--- a/db/migrate/20120723161914_update_histories_trigger.rb
+++ b/db/migrate/20120723161914_update_histories_trigger.rb
@@ -1,4 +1,4 @@
-class UpdateHistoriesTrigger < ActiveRecord::Migration
+class UpdateHistoriesTrigger < ActiveRecord::Migration[5.1]
   def up
     execute <<-SQL.strip_heredoc
       CREATE OR REPLACE FUNCTION history_changes_index_trigger() RETURNS trigger

--- a/db/migrate/20120804130515_drop_server_key.rb
+++ b/db/migrate/20120804130515_drop_server_key.rb
@@ -1,4 +1,4 @@
-class DropServerKey < ActiveRecord::Migration
+class DropServerKey < ActiveRecord::Migration[5.1]
   def up
     drop_table :server_keys
   end

--- a/db/migrate/20120813155642_change_batch_upload_url_to_text.rb
+++ b/db/migrate/20120813155642_change_batch_upload_url_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeBatchUploadUrlToText < ActiveRecord::Migration
+class ChangeBatchUploadUrlToText < ActiveRecord::Migration[5.1]
   def change
     change_column :batch_uploads, :url, :text
   end

--- a/db/migrate/20120830051636_add_updated_at_to_posts.rb
+++ b/db/migrate/20120830051636_add_updated_at_to_posts.rb
@@ -1,4 +1,4 @@
-class AddUpdatedAtToPosts < ActiveRecord::Migration
+class AddUpdatedAtToPosts < ActiveRecord::Migration[5.1]
   def change
     add_column :posts, :updated_at, :timestamp
   end

--- a/db/migrate/20120920171733_remove_fav_count_from_posts.rb
+++ b/db/migrate/20120920171733_remove_fav_count_from_posts.rb
@@ -1,4 +1,4 @@
-class RemoveFavCountFromPosts < ActiveRecord::Migration
+class RemoveFavCountFromPosts < ActiveRecord::Migration[5.1]
   def up
     remove_column :posts, :fav_count
   end

--- a/db/migrate/20120920172947_set_default_for_users_show_samples.rb
+++ b/db/migrate/20120920172947_set_default_for_users_show_samples.rb
@@ -1,4 +1,4 @@
-class SetDefaultForUsersShowSamples < ActiveRecord::Migration
+class SetDefaultForUsersShowSamples < ActiveRecord::Migration[5.1]
   def up
     change_column :users, :show_samples, :boolean, :default => true
   end

--- a/db/migrate/20120920173324_disallow_anonymous_forum_posts.rb
+++ b/db/migrate/20120920173324_disallow_anonymous_forum_posts.rb
@@ -1,4 +1,4 @@
-class DisallowAnonymousForumPosts < ActiveRecord::Migration
+class DisallowAnonymousForumPosts < ActiveRecord::Migration[5.1]
   def up
     change_column :forum_posts, :creator_id, :integer, :null => false
   end

--- a/db/migrate/20120920173803_remove_anonymous_votes_from_posts.rb
+++ b/db/migrate/20120920173803_remove_anonymous_votes_from_posts.rb
@@ -1,4 +1,4 @@
-class RemoveAnonymousVotesFromPosts < ActiveRecord::Migration
+class RemoveAnonymousVotesFromPosts < ActiveRecord::Migration[5.1]
   def up
     remove_column :posts, :anonymous_votes
   end

--- a/db/migrate/20120920174218_remove_last_voter_ip_from_posts.rb
+++ b/db/migrate/20120920174218_remove_last_voter_ip_from_posts.rb
@@ -1,4 +1,4 @@
-class RemoveLastVoterIpFromPosts < ActiveRecord::Migration
+class RemoveLastVoterIpFromPosts < ActiveRecord::Migration[5.1]
   def up
     remove_column :posts, :last_voter_ip
   end

--- a/db/migrate/20120921040720_remove_last_vote_from_posts.rb
+++ b/db/migrate/20120921040720_remove_last_vote_from_posts.rb
@@ -1,4 +1,4 @@
-class RemoveLastVoteFromPosts < ActiveRecord::Migration
+class RemoveLastVoteFromPosts < ActiveRecord::Migration[5.1]
   def up
     remove_column :posts, :last_vote
   end

--- a/db/migrate/20130326154700_add_api_key_to_user.rb
+++ b/db/migrate/20130326154700_add_api_key_to_user.rb
@@ -1,4 +1,4 @@
-class AddApiKeyToUser < ActiveRecord::Migration
+class AddApiKeyToUser < ActiveRecord::Migration[5.1]
   def change
     add_column :users, :api_key, :string
   end

--- a/db/migrate/20130326161630_add_index_to_api_key.rb
+++ b/db/migrate/20130326161630_add_index_to_api_key.rb
@@ -1,4 +1,4 @@
-class AddIndexToApiKey < ActiveRecord::Migration
+class AddIndexToApiKey < ActiveRecord::Migration[5.1]
   def change
     add_index :users, :api_key, :unique => true
   end

--- a/db/migrate/20140309152432_fix_sequence_name.rb
+++ b/db/migrate/20140309152432_fix_sequence_name.rb
@@ -1,4 +1,4 @@
-class FixSequenceName < ActiveRecord::Migration
+class FixSequenceName < ActiveRecord::Migration[5.1]
   def up
     execute "ALTER SEQUENCE favorite_tags_id_seq RENAME TO tag_subscriptions_id_seq"
   end

--- a/db/migrate/20140427041839_remove_non_votes.rb
+++ b/db/migrate/20140427041839_remove_non_votes.rb
@@ -1,4 +1,4 @@
-class RemoveNonVotes < ActiveRecord::Migration
+class RemoveNonVotes < ActiveRecord::Migration[5.1]
   class PostVote < ActiveRecord::Base
   end
 

--- a/db/migrate/20140429125422_fix_post_votes_updated_at.rb
+++ b/db/migrate/20140429125422_fix_post_votes_updated_at.rb
@@ -1,4 +1,4 @@
-class FixPostVotesUpdatedAt < ActiveRecord::Migration
+class FixPostVotesUpdatedAt < ActiveRecord::Migration[5.1]
   def change
     change_column_default :post_votes, :updated_at, nil
   end

--- a/db/migrate/20140905023318_add_post_foreign_key_to_posts_tags.rb
+++ b/db/migrate/20140905023318_add_post_foreign_key_to_posts_tags.rb
@@ -1,4 +1,4 @@
-class AddPostForeignKeyToPostsTags < ActiveRecord::Migration
+class AddPostForeignKeyToPostsTags < ActiveRecord::Migration[5.1]
   def change
     execute <<-SQL
       DELETE FROM posts_tags

--- a/db/migrate/20151207113346_convert_job_tasks_data_data_type_to_jsonb.rb
+++ b/db/migrate/20151207113346_convert_job_tasks_data_data_type_to_jsonb.rb
@@ -1,4 +1,4 @@
-class ConvertJobTasksDataDataTypeToJsonb < ActiveRecord::Migration
+class ConvertJobTasksDataDataTypeToJsonb < ActiveRecord::Migration[5.1]
   def up
     execute <<-SQL
       ALTER TABLE job_tasks RENAME data_as_json TO data;

--- a/db/migrate/20160113112901_fix_batch_uploads_created_at_default.rb
+++ b/db/migrate/20160113112901_fix_batch_uploads_created_at_default.rb
@@ -1,4 +1,4 @@
-class FixBatchUploadsCreatedAtDefault < ActiveRecord::Migration
+class FixBatchUploadsCreatedAtDefault < ActiveRecord::Migration[5.1]
   def up
     execute "ALTER TABLE batch_uploads ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP"
   end

--- a/db/migrate/20160329065325_add_tags_array_to_posts.rb
+++ b/db/migrate/20160329065325_add_tags_array_to_posts.rb
@@ -1,4 +1,4 @@
-class AddTagsArrayToPosts < ActiveRecord::Migration
+class AddTagsArrayToPosts < ActiveRecord::Migration[5.1]
   def change
     add_column :posts, :tags_array, :string, :array => true
   end

--- a/db/migrate/20160329065802_add_trigger_for_posts_tags_array.rb
+++ b/db/migrate/20160329065802_add_trigger_for_posts_tags_array.rb
@@ -1,4 +1,4 @@
-class AddTriggerForPostsTagsArray < ActiveRecord::Migration
+class AddTriggerForPostsTagsArray < ActiveRecord::Migration[5.1]
   def up
     execute <<-SQL.strip_heredoc
       CREATE OR REPLACE FUNCTION posts_tags_array_update() RETURNS trigger AS $$

--- a/db/migrate/20160329154133_remove_tags_index_on_posts.rb
+++ b/db/migrate/20160329154133_remove_tags_index_on_posts.rb
@@ -1,4 +1,4 @@
-class RemoveTagsIndexOnPosts < ActiveRecord::Migration
+class RemoveTagsIndexOnPosts < ActiveRecord::Migration[5.1]
   def up
     remove_column :posts, :tags_index
   end

--- a/db/migrate/20160329160235_remove_posts_tags_index_trigger.rb
+++ b/db/migrate/20160329160235_remove_posts_tags_index_trigger.rb
@@ -1,4 +1,4 @@
-class RemovePostsTagsIndexTrigger < ActiveRecord::Migration
+class RemovePostsTagsIndexTrigger < ActiveRecord::Migration[5.1]
   def up
     execute <<-SQL.strip_heredoc
       DROP TRIGGER trg_posts_tags_index_update ON posts;

--- a/db/migrate/20160329161636_replace_history_changes_value_index.rb
+++ b/db/migrate/20160329161636_replace_history_changes_value_index.rb
@@ -1,4 +1,4 @@
-class ReplaceHistoryChangesValueIndex < ActiveRecord::Migration
+class ReplaceHistoryChangesValueIndex < ActiveRecord::Migration[5.1]
   def up
     change_table :history_changes do |t|
       t.string :value_array, :array => true

--- a/db/migrate/20160330063707_drop_danbooru_text_search_configuration.rb
+++ b/db/migrate/20160330063707_drop_danbooru_text_search_configuration.rb
@@ -1,4 +1,4 @@
-class DropDanbooruTextSearchConfiguration < ActiveRecord::Migration
+class DropDanbooruTextSearchConfiguration < ActiveRecord::Migration[5.1]
   def up
     execute <<-SQL.strip_heredoc
       DROP TEXT SEARCH CONFIGURATION danbooru;


### PR DESCRIPTION
Migrations get aborted when running `rake db:migrate`.

The result error is:

```
rails aborted!
StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:
```

More info: https://stackoverflow.com/questions/44414377/why-is-my-rails-dbmigrate-not-working