### PR TITLE
Fix remove_all_posts in posts browser not removing all thumbnails

### DIFF
--- a/app/javascript/src/legacy/browser-thumb-view.coffee
+++ b/app/javascript/src/legacy/browser-thumb-view.coffee
@@ -557,8 +557,7 @@ ThumbnailView::remove_post = (right) ->
   true
 
 ThumbnailView::remove_all_posts = ->
-  while @remove_post(true)
-      return
+  continue while @remove_post(true)
 
 ### Add the next thumbnail to the left or right side. ###
 


### PR DESCRIPTION
This incidentally fixes a nasty 100% cpu infinite loop that made the posts browser completely lock up for me, when doing just about anything after scrolling the thumbnails.