### PR TITLE
Remove moe.imouto.org from image_service_list

### DIFF
--- a/config/init_config.rb
+++ b/config/init_config.rb
@@ -155,7 +155,6 @@ CONFIG["local_image_service"] = ""
 # List of image services available for similar image searching.
 CONFIG["image_service_list"] = {
   "danbooru.donmai.us" => "http://haruhidoujins.yi.org/multi-search.xml",
-  "moe.imouto.org" => "http://haruhidoujins.yi.org/multi-search.xml",
   "konachan.com" => "http://haruhidoujins.yi.org/multi-search.xml"
 }
 


### PR DESCRIPTION
Upon deploying, user will be unable to access similar_posts. Removing the moe.imouto.org from image_service_list resolves this problem.