### PR TITLE
Tag implication controller refactor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,8 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  NewCops: enable
 Layout/LineLength:
   Max: 200
-Style/FrozenStringLiteralComment:
-  Enabled: false
 Naming/MethodParameterName:
   MinNameLength: 1
-Documentation:
+Style/Documentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+AllCops:
+  TargetRubyVersion: 2.5
+Layout/LineLength:
+  Max: 200
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Naming/MethodParameterName:
+  MinNameLength: 1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,5 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 Naming/MethodParameterName:
   MinNameLength: 1
+Documentation:
+  Enabled: false

--- a/app/controllers/tag_implication_controller.rb
+++ b/app/controllers/tag_implication_controller.rb
@@ -30,6 +30,8 @@ class TagImplicationController < ApplicationController
                     .order_for_listing
                     .search_by_tag_name(params[:query])
                     .paginate(page: page_number, per_page: 20)
+
+    respond_to_list 'implications'
   end
 
   private

--- a/app/controllers/tag_implication_controller.rb
+++ b/app/controllers/tag_implication_controller.rb
@@ -27,8 +27,8 @@ class TagImplicationController < ApplicationController
     return redirect_to_tag_alias_index if searching_aliases?
 
     @implications = TagImplication.retrieve_matching_tag_id
-    @implications = TagImplication.apply_query_filter(params[:query], @implications)
-    @implications = TagImplication.paginate(page: page_number, per_page: 20)
+    @implications = TagImplication.apply_query_filter(params, @implications)
+    @implications = @implications.paginate(page: page_number, per_page: 20)
     respond_to_list('implications')
   end
 

--- a/app/controllers/tag_implication_controller.rb
+++ b/app/controllers/tag_implication_controller.rb
@@ -64,7 +64,7 @@ class TagImplicationController < ApplicationController
   end
 
   def delete_tag_if_privileged_or_creator(ids)
-    if @current_user.is_mod_or_higher? || get_creator_tag
+    if @current_user.is_mod_or_higher? || get_creator_tag(ids)
       ids.each { |x| destroy_tag_and_notify_user(x) }
 
       flash[:notice] = 'Tag implications deleted'
@@ -82,7 +82,7 @@ class TagImplicationController < ApplicationController
     params.require(:tag_implication).permit(:predicate, :consequent, :reason)
   end
 
-  def get_creator_tag
+  def get_creator_tag(ids)
     return TagImplication.where(id: ids, is_pending: true, creator_id: @current_user.id).count == ids.count
   end
 

--- a/app/controllers/tag_implication_controller.rb
+++ b/app/controllers/tag_implication_controller.rb
@@ -1,76 +1,96 @@
 class TagImplicationController < ApplicationController
-  layout "default"
-  before_action :member_only, :only => [:create]
+  layout 'default'
+  before_action :member_only, {only: [:create]}
 
   def create
-    ti = TagImplication.new(tag_implication_params.merge(:is_pending => true, :creator_id => @current_user.id))
-
-    if ti.save
-      flash[:notice] = "Tag implication created"
-    else
-      flash[:notice] = "Error: " + ti.errors.full_messages.join(", ")
-    end
-
-    redirect_to :action => "index"
+    ti = TagImplication.new(tag_implication_params.merge({is_pending: true, creator_id: @current_user.id}))
+    flash[:notice] = ti.save ? 'Tag implication created' : 'Error: ' + ti.errors.full_messages.join(', ')
+    redirect_to action: 'index'
   end
 
   def update
     ids = params[:implications].try(:keys)
 
     case params[:commit]
-    when "Delete"
-      if @current_user.is_mod_or_higher? || TagImplication.where(:id => ids, :is_pending => true, :creator_id => @current_user.id).count == ids.count
-        ids.each { |x| TagImplication.find(x).destroy_and_notify(@current_user, params[:reason]) }
-
-        flash[:notice] = "Tag implications deleted"
-        redirect_to :action => "index"
-      else
-        access_denied
-      end
-
-    when "Approve"
-      if @current_user.is_mod_or_higher?
-        ids.each do |x|
-          if CONFIG["enable_asynchronous_tasks"]
-            JobTask.create(:task_type => "approve_tag_implication", :status => "pending", :data => { "id" => x, "updater_id" => @current_user.id, "updater_ip_addr" => request.remote_ip })
-          else
-            TagImplication.find(x).approve(@current_user.id, request.remote_ip)
-          end
-        end
-
-        flash[:notice] = "Tag implication approval jobs created"
-        redirect_to :controller => "job_task", :action => "index"
-      else
-        access_denied
-      end
+    when 'Delete'
+      delete_tag_if_privileged_or_creator(ids)
+    when 'Approve'
+      approve_tag_if_privileged(ids)
     else
       head :bad_request
     end
   end
 
   def index
-    if params[:commit] == "Search Aliases"
-      return redirect_to :controller => "tag_alias", :action => "index", :query => params[:query]
+    if params[:commit] == 'Search Aliases'
+      return redirect_to controller: 'tag_alias', action: 'index', query: params[:query]
     end
 
     # FIXME: subquery in order
-    @implications = TagImplication.order(Arel.sql("is_pending DESC, (SELECT name FROM tags WHERE id = tag_implications.predicate_id), (SELECT name FROM tags WHERE id = tag_implications.consequent_id)"))
+    @implications = TagImplication.order(Arel.sql('is_pending DESC, (SELECT name FROM tags WHERE id = tag_implications.predicate_id), (SELECT name FROM tags WHERE id = tag_implications.consequent_id)'))
 
     if params[:query]
-      tag_ids = Tag.where("name ILIKE ?", "*#{params[:query]}*".to_escaped_for_sql_like).select(:id)
+      tag_ids = Tag.where('name ILIKE ?', '*#{params[:query]}*'.to_escaped_for_sql_like).select(:id)
       @implications = @implications
-        .where("predicate_id IN (?) OR consequent_id IN (?)", tag_ids, tag_ids)
-        .order(:is_pending => :desc, :consequent_id => :asc)
+        .where('predicate_id IN (?) OR consequent_id IN (?)', tag_ids, tag_ids)
+        .order(is_pending: :desc, consequent_id: :asc)
     end
 
-    @implications = @implications.paginate :page => page_number, :per_page => 20
-
-    respond_to_list("implications")
+    @implications = @implications.paginate page: page_number, per_page: 20
+    respond_to_list('implications')
   end
 
   private
 
+  def approve_tag_if_privileged(ids)
+    if @current_user.is_mod_or_higher?
+      ids.each do |x|
+        approve_tag(x)
+      end
+
+      flash[:notice] = 'Tag implication approval jobs created'
+      redirect_to controller: 'job_task', action: 'index'
+    else
+      access_denied
+    end
+  end
+
+  def approve_tag(x)
+    if CONFIG['enable_asynchronous_tasks']
+      JobTask.create({task_type: 'approve_tag_implication', status: 'pending', data: get_data(x)})
+    else
+      find_and_approve(x)
+    end
+  end
+
+  def delete_tag_if_privileged_or_creator(ids)
+    if @current_user.is_mod_or_higher? || get_creator_tag
+      ids.each { |x| destroy_tag_and_notify_user(x) }
+
+      flash[:notice] = 'Tag implications deleted'
+      redirect_to action: 'index'
+    else
+      access_denied
+    end
+  end
+
+  def destroy_tag_and_notify_user(x)
+    TagImplication.find(x).destroy_and_notify(@current_user, params[:reason])
+  end
+
   def tag_implication_params
     params.require(:tag_implication).permit(:predicate, :consequent, :reason)
+  end
+
+  def get_creator_tag
+    return TagImplication.where(id: ids, is_pending: true, creator_id: @current_user.id).count == ids.count
+  end
+
+  def get_data(x)
+    return {'id': x, 'updater_id': @current_user.id, 'updater_ip_addr': request.remote_ip}
+  end
+
+  def find_and_approve(x)
+    TagImplication.find(x).approve(@current_user.id, request.remote_ip)
   end
 end

--- a/app/controllers/tag_implication_controller.rb
+++ b/app/controllers/tag_implication_controller.rb
@@ -26,10 +26,10 @@ class TagImplicationController < ApplicationController
   def index
     return redirect_to_tag_alias_index if searching_aliases?
 
-    @implications = TagImplication.retrieve_matching_tag_id
-    @implications = TagImplication.apply_query_filter(params, @implications)
-    @implications = @implications.paginate(page: page_number, per_page: 20)
-    respond_to_list('implications')
+    @implications = TagImplication
+                    .order_for_listing
+                    .search_by_tag_name(params[:query])
+                    .paginate(page: page_number, per_page: 20)
   end
 
   private
@@ -87,7 +87,7 @@ class TagImplicationController < ApplicationController
   end
 
   def format_with_user_info(x)
-    { id: x, updater_id: @current_user.id, updater_ip_addr: request.remote_ip }
+    { 'id' => x, 'updater_id' => @current_user.id, 'updater_ip_addr' => request.remote_ip }
   end
 
   def find_and_approve(x)

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -25,15 +25,8 @@ class TagImplication < ApplicationRecord
     order(Arel.sql('is_pending DESC, (SELECT name FROM tags WHERE id = tag_implications.predicate_id), (SELECT name FROM tags WHERE id = tag_implications.consequent_id)'))
   end
 
-  def self.retrieve_existing_tag_matching_id(query, implications)
-    tag_ids = Tag.where('name ILIKE :query', query: "*#{query}*").select(:id)
-    implications
-      .where('predicate_id IN (:tag_ids) OR consequent_id IN (:tag_ids)', tag_ids: tag_ids)
-      .order(is_pending: :desc, consequent_id: :asc)
-  end
-
   def self.apply_query_filter(params, implications)
-    return unless params[:query]
+    return implications unless params[:query].present?
 
     tag_ids = Tag.where('name ILIKE ?', "*#{params[:query]}*".to_escaped_for_sql_like).select(:id)
     implications

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -2,18 +2,16 @@
 
 class TagImplication < ApplicationRecord
   # FIXME: subquery in order
-  def self.order_for_listing
+  scope :order_for_listing, lambda {
     order(Arel.sql('is_pending DESC, (SELECT name FROM tags WHERE id = tag_implications.predicate_id), (SELECT name FROM tags WHERE id = tag_implications.consequent_id)'))
-  end
+  }
 
-  def self.search_by_tag_name(query)
-    return self unless query.present?
-
+  scope :search_by_tag_name, lambda { |query|
     tag_ids = Tag.where('name ILIKE ?', "*#{query}*".to_escaped_for_sql_like).select(:id)
 
     where('predicate_id IN (?) OR consequent_id IN (?)', tag_ids, tag_ids)
       .order(is_pending: :desc, consequent_id: :asc)
-  end
+  }
 
   def self.with_implied(tags)
     return [] if tags.blank?

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -7,6 +7,8 @@ class TagImplication < ApplicationRecord
   }
 
   scope :search_by_tag_name, lambda { |query|
+    return if query.blank?
+
     tag_ids = Tag.where('name ILIKE ?', "*#{query}*".to_escaped_for_sql_like).select(:id)
 
     where('predicate_id IN (?) OR consequent_id IN (?)', tag_ids, tag_ids)

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -32,10 +32,13 @@ class TagImplication < ApplicationRecord
       .order(is_pending: :desc, consequent_id: :asc)
   end
 
-  def self.apply_query_filter(query, implications)
-    return unless query.present?
+  def self.apply_query_filter(params, implications)
+    return unless params[:query]
 
-    retrieve_existing_tag_matching_id(query, implications)
+    tag_ids = Tag.where('name ILIKE ?', "*#{params[:query]}*".to_escaped_for_sql_like).select(:id)
+    implications
+      .where('predicate_id IN (?) OR consequent_id IN (?)', tag_ids, tag_ids)
+      .order(is_pending: :desc, consequent_id: :asc)
   end
 
   def predicate


### PR DESCRIPTION
Fix hash suggestions to use ruby >1.9. Apply format fixes, and added helper methods to reduce complexity. Add rubocop configuration to utilize checks on later ruby versions.
Improves tag implication from B to A: ([link to report](https://codeclimate.com/github/munchtoast/moebooru/app/controllers/tag_implication_controller.rb?strict=false&to_sha=8f2e8a64a6acf056c74b720c8565c5024017de8b))

Rails test:
```
> rails test test/controllers/tag_implication_controller_test.rb 
Run options: --seed 9984

# Running:
.
Finished in 1.826479s, 0.5475 runs/s, 1.0950 assertions/s.
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```