### PR TITLE
docs: don't encourage unsafe practices in JSON parsing example

### DIFF
--- a/app/views/help/api.en.html.erb
+++ b/app/views/help/api.en.html.erb
@@ -82,7 +82,7 @@
       <h4>JSON Responses</h4>
       <p>While you will probably want to work with XML in the majority of cases, if you're writing something in Javascript then the JSON responses may be preferable. They are much faster to parse and there's less code to write to get your data structure:</p>
       <div class="code">
-        var data = eval("(" + responseText + ")")<br>
+        var data = JSON.parse(responseText)<br>
         alert(data.response)
       </div>
     </div>


### PR DESCRIPTION
In the current docs, the example for parsing JSON responses from the API, the unsafe `eval` JavaScript API is used instead of the standard `JSON.parse`. I think encouraging these practices is a really bad idea, since there are several security implications with using eval in any production code. eval has its uses, but parsing JSON data (especially when completely unsanitized) is not one of them. Experienced JS developers will likely not use eval despite the docs telling them to do so, but this does put new developers at risk, who just follow every instruction verbatim.

For context, eval is a function that can be used to evaluate JavaScript code. Any JavaScript code. This can easily lead to XSS vulnerabilities. For example, a bad actor could perform a MITM attack (or take control over the Moebooru instance) and make it so the API responds with the following:

```js
1); alert('XSS vulnerability!'); (1
```

This is a perfectly correct input for the provided eval example. While the alert example is basically harmless, one could also grab session tokens or cookies from the website and send them to a third-party server.

In Node.js context, this might be even more dangerous, as eval will freely give access to the entire operating system through the Node API.

```js
1); const fs = require('fs'); const dirs = fs.readdirSync('.'); console.log(dirs); (1
```

API consumers should instead use the `JSON.parse` API, which is not only fewer characters to type but it's also much safer and faster than any eval + sanitization implementation.